### PR TITLE
Inline `debug?` call inside `dev-setup`

### DIFF
--- a/src/leiningen/new/reagent_figwheel/src/cljs/core.cljs
+++ b/src/leiningen/new/reagent_figwheel/src/cljs/core.cljs
@@ -30,7 +30,7 @@
 ;; Initialize App
 
 (defn dev-setup []
-  (when debug?
+  (when ^boolean js/goog.DEBUG
     (enable-console-print!){{#re-frisk?}}
     (rf/enable-frisk!)
     (rf/add-data :app-state app-state){{/re-frisk?}}

--- a/src/leiningen/new/reagent_figwheel/src/cljs/core_firebase.cljs
+++ b/src/leiningen/new/reagent_figwheel/src/cljs/core_firebase.cljs
@@ -46,7 +46,7 @@
 ;; Initialize App
 
 (defn dev-setup []
-  (when debug?
+  (when ^boolean js/goog.DEBUG
     (enable-console-print!){{#re-frisk?}}
     (rf/enable-frisk!)
     (rf/add-data :app-state app-state){{/re-frisk?}}

--- a/src/leiningen/new/reagent_figwheel/src/cljs/core_firebase_routes.cljs
+++ b/src/leiningen/new/reagent_figwheel/src/cljs/core_firebase_routes.cljs
@@ -91,7 +91,7 @@
 
 
 (defn dev-setup []
-  (when debug?
+  (when ^boolean js/goog.DEBUG
     (enable-console-print!){{#re-frisk?}}
     (rf/enable-frisk!)
     (rf/add-data :app-state app-state){{/re-frisk?}}

--- a/src/leiningen/new/reagent_figwheel/src/cljs/core_keechma.cljs
+++ b/src/leiningen/new/reagent_figwheel/src/cljs/core_keechma.cljs
@@ -80,7 +80,7 @@
   (reset! running-app (app-state/start! app-definition)))
 
 (defn dev-setup []
-  (when debug?
+  (when ^boolean js/goog.DEBUG
     (enable-console-print!)
     (println "dev mode"){{#devtools?}}
     (devtools/install!){{/devtools?}}

--- a/src/leiningen/new/reagent_figwheel/src/cljs/core_petrol.cljs
+++ b/src/leiningen/new/reagent_figwheel/src/cljs/core_petrol.cljs
@@ -58,7 +58,7 @@
 ;; Initialize App
 
 (defn dev-setup []
-  (when debug?
+  (when ^boolean js/goog.DEBUG
     (enable-console-print!){{#re-frisk?}}
     (rf/enable-frisk!)
     (rf/add-data :app-state app-state){{/re-frisk?}}

--- a/src/leiningen/new/reagent_figwheel/src/cljs/core_petrol_routes.cljs
+++ b/src/leiningen/new/reagent_figwheel/src/cljs/core_petrol_routes.cljs
@@ -110,7 +110,7 @@
     [(page page-key) ui-channel app]))
 
 (defn dev-setup []
-  (when debug?
+  (when ^boolean js/goog.DEBUG
     (enable-console-print!){{#re-frisk?}}
     (rf/enable-frisk!)
     (rf/add-data :app-state app-state){{/re-frisk?}}

--- a/src/leiningen/new/reagent_figwheel/src/cljs/core_routes.cljs
+++ b/src/leiningen/new/reagent_figwheel/src/cljs/core_routes.cljs
@@ -79,7 +79,7 @@
     [(page page-key) ratom]))
 
 (defn dev-setup []
-  (when debug?
+  (when ^boolean js/goog.DEBUG
     (enable-console-print!){{#re-frisk?}}
     (rf/enable-frisk!)
     (rf/add-data :app-state app-state){{/re-frisk?}}


### PR DESCRIPTION
Inlining this function call shaves 65kb of the minified output on a clean
project with only the `+devtools` option.

The size of the non-inlined version matches exactly that of the inlined version
with the `goog.DEBUG` flag excluded. Most likely, the indirection is preventing
Google Closure from eliminating the dead code from the final build.

| Type                                            | Size [KB] |
|-------------------------------------------------|----------:|
| Baseline (no `+devtools`)                       |       296 |
| Plain `+devtools` template                      |       546 |
| Inlined `debug?`                                |       481 |
| Inlined `debug?`, `goog.DEBUG` removed          |       546 |
| Inlined `dev-setup` inside `main`               |       546 |
| Inlined `dev-setup` and `debug?` inside `main`  |       481 |
| Inlined `dev-setup` and `debug?` outside `main` |       481 |

`debug?` looks like the sole culprit. 
Unfortunately, even inlining it still leaves us very far from the baseline.

I've left the function alone, as it can be useful for other purposes, but a
comment regarding this "feature" would be nice!