### PR TITLE
Bump lein-garden version

### DIFF
--- a/src/leiningen/new/reagent_figwheel/gadfly/project.clj
+++ b/src/leiningen/new/reagent_figwheel/gadfly/project.clj
@@ -9,7 +9,7 @@
                  [secretary "1.2.3"]]
 
   :plugins [[lein-cljsbuild "1.1.3"]
-            [lein-garden "0.2.6"]]
+            [lein-garden "0.3.0"]]
 
   :clean-targets ^{:protect false} ["resources/public/js"
                                     "resources/public/css"

--- a/src/leiningen/new/reagent_figwheel/project.clj
+++ b/src/leiningen/new/reagent_figwheel/project.clj
@@ -15,7 +15,7 @@
   :source-paths ["src/clj"]
 
   :plugins [[lein-cljsbuild "1.1.4"]{{#garden?}}
-            [lein-garden "0.2.8"]{{/garden?}}{{#less?}}
+            [lein-garden "0.3.0"]{{/garden?}}{{#less?}}
             [lein-less "1.7.5"]{{/less?}}]
 
   :clean-targets ^{:protect false} ["resources/public/js"


### PR DESCRIPTION
This fixes:

```
$ lein garden auto
Compiling Garden...
Tried to use insecure HTTP repository without TLS.
This is almost certainly a mistake; however in rare cases where it's
intentional please see `lein help faq` for details.
```

which has been reported in issues:
- https://github.com/noprompt/garden/issues/163
- https://github.com/gadfly361/reagent-figwheel/issues/12